### PR TITLE
chef_vault_item - do not default to development workflow in production environment

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,8 @@ suites:
   run_list:
   - recipe[chef-vault]
   - recipe[test]
+  attributes:
+    dev_mode: true
 
 - name: secret_resource
   run_list:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ not as a fall back to avoid issues loading encrypted items.
   chef-vault gem if required. Default is `~> 2.2`, as that version was
   used for testing.
 
+The following attribute is special and not specifically related to
+this cookbook, but is used in the helper.
+
+* `node['dev_mode']` - If this is true, `chef_vault_item` will attempt
+  to load the specified item as a regular Data Bag Item with
+  `Chef::DataBagItem.load`. This is intended to be used only for
+  testing, and not as a fall back to avoid issues loading encrypted
+  items.
+
+
 ## Resources
 
 ### chef_vault_secret

--- a/libraries/chef_vault_item.rb
+++ b/libraries/chef_vault_item.rb
@@ -38,8 +38,12 @@ module ChefVaultItem
 
     begin
       ChefVault::Item.load(bag, item)
-    rescue ChefVault::Exceptions::KeysNotFound, ChefVault::Exceptions::SecretDecryption
-      Chef::DataBagItem.load(bag, item)
+    rescue ChefVault::Exceptions::KeysNotFound, ChefVault::Exceptions::SecretDecryption => exception
+      if node['dev_mode']
+        Chef::DataBagItem.load(bag, item)
+      else
+        raise exception
+      end
     end
   end
 end


### PR DESCRIPTION
fix for #26

it is much better practice to explicitly enable a development workflow rather than
default to poor behavior in production.
